### PR TITLE
T5089: bindings for configtree union and optional arg 'ordered_values'

### DIFF
--- a/lib/bindings.ml
+++ b/lib/bindings.ml
@@ -37,8 +37,8 @@ let from_string s =
 
 let get_error () = !error_message
 
-let render_config c_ptr =
-    CT.render_config (Root.get c_ptr)
+let render_config c_ptr ord_val =
+    CT.render_config ~ord_val:ord_val (Root.get c_ptr)
 
 let render_json c_ptr =
     CT.render_json (Root.get c_ptr)
@@ -217,7 +217,7 @@ struct
   let () = I.internal "destroy" ((ptr void) @-> returning void) destroy
   let () = I.internal "from_string" (string @-> returning (ptr void)) from_string
   let () = I.internal "get_error" (void @-> returning string) get_error
-  let () = I.internal "to_string"  ((ptr void) @-> returning string) render_config
+  let () = I.internal "to_string"  ((ptr void) @-> bool @-> returning string) render_config
   let () = I.internal "to_json" ((ptr void) @-> returning string) render_json
   let () = I.internal "to_json_ast" ((ptr void) @-> returning string) render_json_ast
   let () = I.internal "to_commands" ((ptr void) @-> string @-> returning string) render_commands

--- a/lib/bindings.ml
+++ b/lib/bindings.ml
@@ -201,6 +201,15 @@ let show_diff cmds path c_ptr_l c_ptr_r =
         | CD.Incommensurable -> error_message := "Incommensurable"; "#1@"
         | CD.Empty_comparison -> error_message := "Empty comparison"; "#1@"
 
+let tree_union c_ptr_l c_ptr_r =
+    let ct_l = Root.get c_ptr_l in
+    let ct_r = Root.get c_ptr_r in
+    try
+        let ct_ret = CD.tree_union ct_l ct_r in
+        Ctypes.Root.create ct_ret
+    with
+        CD.Nonexistent_child -> error_message := "Nonexistent child"; Ctypes.null
+
 module Stubs(I : Cstubs_inverted.INTERNAL) =
 struct
 
@@ -229,4 +238,5 @@ struct
   let () = I.internal "diff_tree" (string @-> (ptr void) @-> (ptr void) @-> returning (ptr void)) diff_tree
   let () = I.internal "trim_tree" ((ptr void) @-> (ptr void) @-> returning (ptr void)) trim_tree
   let () = I.internal "show_diff" (bool @-> string @-> (ptr void) @-> (ptr void) @-> returning string) show_diff
+  let () = I.internal "tree_union" ((ptr void) @-> (ptr void) @-> returning (ptr void)) tree_union
 end


### PR DESCRIPTION
Draft PR depending on:
https://github.com/vyos/vyos1x-config/pull/14
https://github.com/vyos/vyos1x-config/pull/15

Both additions to lib/bindings.ml to support unit tests.