### PR TITLE
T5251: catch error Vytree.Nonexistent_path in delete_value

### DIFF
--- a/lib/bindings.ml
+++ b/lib/bindings.ml
@@ -85,7 +85,9 @@ let delete_value c_ptr path value =
         let new_ct = CT.delete ct path (Some value) in
         Root.set c_ptr new_ct;
         0 (* return 0 *)
-    with CT.No_such_value -> 1
+    with
+    | Vytree.Nonexistent_path -> 1
+    | CT.No_such_value -> 2
 
 let delete_node c_ptr path =
     let ct = Root.get c_ptr in


### PR DESCRIPTION
The function delete_value can implicitly raise Vytree.Nonexistent_path; catch and return non-zero value in that case.