### PR TITLE
T7728: T7734: update commit hash for dynamically generate proposed config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,8 @@ $(BUILDDIR)/%.cmx: %.ml
 $(GENERATOR): $(GENERATOR_FILES)
 	ocamlfind opt -o $@ -I $(BUILDDIR)/lib -linkpkg -thread -package $(PACKAGES) $^
 
+deb:
+	dpkg-buildpackage -uc -us -tc -b
+
 clean:
 	rm -rf $(BUILDDIR)

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 DIR=$1
 
 sudo sh -c 'eval $(opam env --root=/opt/opam --set-root) && opam pin add vyos1x-config https://github.com/vyos/vyos1x-config.git#b53326dce7dd2dabad2677ad82de4fcd4ea85524 -y'
-sudo sh -c 'eval $(opam env --root=/opt/opam --set-root) && opam pin add vyconf https://github.com/vyos/vyconf.git#88d926d30b4219c50bbb1167ab58d60c5c5d2bbb -y'
+sudo sh -c 'eval $(opam env --root=/opt/opam --set-root) && opam pin add vyconf https://github.com/vyos/vyconf.git#2da0981501a9bec8b69d29f1e52c10db90571aa4 -y'
 
 eval `opam config env`
 make clean


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Update commit hash for the changes in:
https://github.com/vyos/vyconf/pull/30

Note that the above is the key ingredient in extending commit-confirm to the vyconf context: a minimal PR for vyos-1x will resolve https://vyos.dev/T7493 as a corollary.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): Internal change.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
